### PR TITLE
Add support for page calls and fix use of _last_visit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,3 +100,26 @@ CustomerIO.prototype.visit = function(message, fn){
   .type('json')
   .end(this.handle(fn));
 };
+
+/**
+ * Page.
+ *
+ * Pages are custom events with type "page" and name set to the URL.
+ *
+ * @param {Page} page
+ * @param {Function} fn
+ * @api public
+ */
+
+CustomerIO.prototype.page = function(page, fn){
+  var self = this;
+  this.visit(page, function(err){
+    if (err) return fn(err);
+    self
+    .post(page.userId() + '/events')
+    .auth(self.settings.siteId, self.settings.apiKey)
+    .send(mapper.page(page))
+    .type('json')
+    .end(self.handle(fn));
+  });
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,15 +33,13 @@ var CustomerIO = module.exports = integration('Customer.io')
  */
 
 CustomerIO.prototype.identify = function(identify, fn){
-  var self = this;
-  this.visit(identify, function(){
-    self
-    .put(identify.userId())
-    .auth(self.settings.siteId, self.settings.apiKey)
-    .type('json')
-    .send(mapper.identify(identify))
-    .end(self.handle(fn));
-  });
+  if (!identify.active()) return setImmediate(fn);
+  this
+  .put(identify.userId())
+  .auth(this.settings.siteId, this.settings.apiKey)
+  .type('json')
+  .send(mapper.identify(identify))
+  .end(this.handle(fn));
 };
 
 /**
@@ -71,16 +69,13 @@ CustomerIO.prototype.group = function(group, fn){
  */
 
 CustomerIO.prototype.track = function(track, fn){
-  var self = this;
-  this.visit(track, function(err){
-    if (err) return fn(err);
-    self
-    .post(track.userId() + '/events')
-    .auth(self.settings.siteId, self.settings.apiKey)
-    .send(mapper.track(track))
-    .type('json')
-    .end(self.handle(fn));
-  });
+  if (!track.active()) return setImmediate(fn);
+  this
+  .post(track.userId() + '/events')
+  .auth(this.settings.siteId, this.settings.apiKey)
+  .send(mapper.track(track))
+  .type('json')
+  .end(this.handle(fn));
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,6 @@ var CustomerIO = module.exports = integration('Customer.io')
  */
 
 CustomerIO.prototype.identify = function(identify, fn){
-  if (!identify.active()) return setImmediate(fn);
   this
   .put(identify.userId())
   .auth(this.settings.siteId, this.settings.apiKey)
@@ -69,7 +68,6 @@ CustomerIO.prototype.group = function(group, fn){
  */
 
 CustomerIO.prototype.track = function(track, fn){
-  if (!track.active()) return setImmediate(fn);
   this
   .post(track.userId() + '/events')
   .auth(this.settings.siteId, this.settings.apiKey)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -71,3 +71,24 @@ exports.track = function(msg){
     name: msg.event()
   }
 };
+
+/**
+ * Map page `msg`.
+ *
+ * @param {Facade} msg
+ * @param {Object} settings
+ * @return {Object}
+ */
+
+exports.page = function(msg){
+  var props = traverse(msg.properties());
+  var url = props.url;
+  delete props.url;
+
+  return {
+    timestamp: time(msg.timestamp()),
+    type: 'page',
+    name: url,
+    data: convert(props, time)
+  }
+};

--- a/test/fixtures/page-basic.json
+++ b/test/fixtures/page-basic.json
@@ -1,0 +1,22 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "date": "2014-01-01",
+      "title": "Welcome | Initech",
+      "url": "http://www.initech.com"
+    }
+  },
+  "output": {
+    "timestamp": 1388534400,
+    "type": "page",
+    "name": "http://www.initech.com",
+    "data": {
+      "date": 1388534400,
+      "title": "Welcome | Initech"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -94,6 +94,7 @@ describe('Customer.io', function(){
       payload.name = url;
       test
         .page(page)
+        .requests(2)
         .request(1)
         .sends(payload)
         .expects(200, done)
@@ -116,6 +117,7 @@ describe('Customer.io', function(){
       payload.name = track.event();
       test
         .track(track)
+        .requests(1)
         .request(1)
         .sends(payload)
         .expects(200, done)
@@ -140,6 +142,7 @@ describe('Customer.io', function(){
       payload = convert(payload, time);
       test
         .identify(identify)
+        .requests(1)
         .request(1)
         .sends(payload)
         .expects(200, done);
@@ -173,6 +176,7 @@ describe('Customer.io', function(){
       payload.email = group.proxy('traits.email');
       test
         .group(group)
+        .requests(1)
         .request(1)
         .sends(payload)
         .expects(200, done);

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,39 @@ describe('Customer.io', function(){
         test.maps('track-basic');
       });
     });
+
+    describe('page', function(){
+      it('should map basic message', function(){
+        test.maps('page-basic');
+      });
+    });
+  });
+
+  describe('.page()', function(){
+    it('should get a good response from the API', function(done){
+      var page = helpers.page();
+      var data = helpers.page().properties();
+      var url = data.url;
+      delete data.url;
+
+      payload.timestamp = time(page.timestamp());
+      payload.data = convert(data, time);
+      payload.type = 'page';
+      payload.name = url;
+      test
+        .page(page)
+        .request(1)
+        .sends(payload)
+        .expects(200, done)
+    });
+
+    it('will error on an invalid set of keys', function(done){
+      test
+        .set({ apiKey: 'x', siteId: 'x' })
+        .page(helpers.page())
+        .expects(401)
+        .error(done);
+    });
   });
 
   describe('.track()', function(){


### PR DESCRIPTION
Page events are pushed to Customer.io as custom events, with the "type" field set to "page", and the "name" field set to the URL of the page.
